### PR TITLE
replace empty checklist item name with a dash, fixes #3

### DIFF
--- a/app/Trello/API/ChecklistClient.php
+++ b/app/Trello/API/ChecklistClient.php
@@ -30,7 +30,7 @@ trait ChecklistClient
     public static function createCheckitem(Checklist $checklist, string $name, bool $checked = false): Checkitem
     {
         return new Checkitem(static::client()->post("checklists/{$checklist->id}/checkItems", [
-            'name' => $name,
+            'name' => (strlen( $name ) === 0) ? "-" : $name,
             'checked' => $checked,
             ...static::auth(),
         ])->json());

--- a/app/Trello/API/ChecklistClient.php
+++ b/app/Trello/API/ChecklistClient.php
@@ -30,7 +30,7 @@ trait ChecklistClient
     public static function createCheckitem(Checklist $checklist, string $name, bool $checked = false): Checkitem
     {
         return new Checkitem(static::client()->post("checklists/{$checklist->id}/checkItems", [
-            'name' => (strlen( $name ) === 0) ? "-" : $name,
+            'name' => $name ?: '-',
             'checked' => $checked,
             ...static::auth(),
         ])->json());


### PR DESCRIPTION
I found this useful as I sometimes accidently add emptly lines to a checklist.